### PR TITLE
Make link-wrap.sh Linux/macOS cross-platform

### DIFF
--- a/ledger_device_sdk/link_wrap.sh
+++ b/ledger_device_sdk/link_wrap.sh
@@ -28,7 +28,7 @@ llvm-objcopy --dump-section .rel.nvm_data=$OUT-nvm-reloc $OUT /dev/null || true
 cat $OUT-rodata-reloc $OUT-nvm-reloc $OUT-data-reloc > $OUT-relocs || true
 
 reloc_allocated_size="$((0x$(llvm-nm $OUT | grep _reloc_size | cut -d' ' -f1)))"
-reloc_real_size="$(stat -c %s $OUT-relocs)"
+reloc_real_size="$(wc -c < "$OUT-relocs")"
 # Check that our relocations _actually_ fit.
 if [ "$reloc_real_size" -gt "$reloc_allocated_size" ]
 then


### PR DESCRIPTION
Replacing `stat -c %z` with `wc -c < ' lets link-wrap.sh work on both Linux and macOS, whereas the stat command works differently between the two platforms.